### PR TITLE
Add type: object for some schemas openapi-generator-cli choked on

### DIFF
--- a/open_api_spec.yml
+++ b/open_api_spec.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Fireblocks API
-  version: "1.7.1"
+  version: "1.7.2"
   contact:
     email: support@fireblocks.com
 servers:
@@ -3200,7 +3200,8 @@ paths:
           application/json:
             schema:
               oneOf:
-                - properties:
+                - type: object
+                  properties:
                     address:
                       type: string
                       description: The wallet's address (or xpub) of the wallet
@@ -3209,11 +3210,13 @@ paths:
                       description: For XRP wallets, the destination tag; for EOS/XLM, the memo; for the fiat providers (BLINC by BCB Group), the Bank Transfer Description
                   required:
                     - address
-                - properties:
+                - type: object
+                  properties:
                     additionalInfo:
                       type: object
                       oneOf:
-                        - properties:
+                        - type: object
+                          properties:
                             accountHolderGivenName:
                               type: string
                             accountHolderSurname:
@@ -3245,7 +3248,8 @@ paths:
                             - iban
                             - ibanCity
                             - ibanCountry
-                        - properties:
+                        - type: object
+                          properties:
                             accountHolderGivenName:
                               type: string
                             accountHolderSurname:
@@ -3277,7 +3281,8 @@ paths:
                             - abaRoutingNumber
                             - abaAccountNumber
                             - abaCountry
-                        - properties:
+                        - type: object
+                          properties:
                             speiClabe:
                               type: string
                             speiName:

--- a/test.yml
+++ b/test.yml
@@ -3246,7 +3246,8 @@ paths:
           application/json:
             schema:
               oneOf:
-                - properties:
+                - type: object
+                  properties:
                     address:
                       type: string
                       description: The wallet's address (or xpub) of the wallet
@@ -3255,11 +3256,13 @@ paths:
                       description: For XRP wallets, the destination tag; for EOS/XLM, the memo; for the fiat providers (BLINC by BCB Group), the Bank Transfer Description
                   required:
                     - address
-                - properties:
+                - type: object
+                  properties:
                     additionalInfo:
                       type: object
                       oneOf:
-                        - properties:
+                        - type: object
+                          properties:
                             accountHolderGivenName:
                               type: string
                             accountHolderSurname:
@@ -3291,7 +3294,8 @@ paths:
                             - iban
                             - ibanCity
                             - ibanCountry
-                        - properties:
+                        - type: object
+                          properties:
                             accountHolderGivenName:
                               type: string
                             accountHolderSurname:
@@ -3323,7 +3327,8 @@ paths:
                             - abaRoutingNumber
                             - abaAccountNumber
                             - abaCountry
-                        - properties:
+                        - type: object
+                          properties:
                             speiClabe:
                               type: string
                             speiName:


### PR DESCRIPTION
An openapi generator I'm using chokes on this part with the error message below. Adding type: object for these schemas solves my problem.

```
[main] WARN  o.o.codegen.DefaultCodegen - The following schema has undefined (null) baseType. It could be due to form parameter defined in OpenAPI v2 spec with incorrect consumes. A correc
t 'consumes' for form parameters should be 'application/x-www-form-urlencoded' or 'multipart/?'
[main] WARN  o.o.codegen.DefaultCodegen - schema: class ComposedSchema {
    class Schema {
        type: null
        format: null
        $ref: null
        description: null
        title: null
        multipleOf: null
        maximum: null
        exclusiveMaximum: null
        minimum: null
        exclusiveMinimum: null
        maxLength: null
        minLength: null
        pattern: null
        maxItems: null
        minItems: null
        uniqueItems: null
        maxProperties: null
        minProperties: null
        required: null
        not: null
        properties: null
        additionalProperties: null
        nullable: true
        readOnly: null
        writeOnly: null
        example: null
        externalDocs: null
        deprecated: null
        discriminator: null
        xml: null
    }
}
[main] WARN  o.o.codegen.DefaultCodegen - codegenModel is null. Default to UNKNOWN_BASE_TYPE
```