### PR TITLE
Make standard optional in asset response

### DIFF
--- a/open_api_spec.yml
+++ b/open_api_spec.yml
@@ -8973,7 +8973,6 @@ components:
             - symbol
             - name
             - decimals
-            - standard
         metadata:
           type: object
           properties:

--- a/test.yml
+++ b/test.yml
@@ -9119,7 +9119,6 @@ components:
             - symbol
             - name
             - decimals
-            - standard
         metadata:
           type: object
           properties:


### PR DESCRIPTION
This pull request updates the docs for asset response by making the standard property optional.