### PR TITLE
preHash object in UnsignedMessage schema

### DIFF
--- a/api-spec-v2.yaml
+++ b/api-spec-v2.yaml
@@ -14498,11 +14498,34 @@ components:
       properties:
         mevProtection:
           $ref: '#/components/schemas/MevProtection'
+    PreHash:
+      type: object
+      description: |
+        The prehash object for ECDSA RAW signing requests. 
+        The prehash object contains the content to sign (the actual message in hex representation) and the hashing algorithm to use before signing.
+      properties:
+        content:
+          type: string
+          description: The prehashed content to sign on in hex representation.
+          example: 48656c6c6f2046697265626c6f636b73210a
+        hashAlgorithm:
+          type: string
+          description: The hashing algorithm to use in order to hash the content before the signature process
+          enum:
+            - SHA256
+            - KECCAK256
+            - SHA3
+            - BLAKE2
+            - DOUBLE_SHA256
     UnsignedMessage:
       type: object
       properties:
+        preHash:
+          $ref: '#/components/schemas/PreHash'
         content:
-          description: Content to sign
+          description: |
+            Content to sign on. 
+            Should be 32 bytes long for ECDSA (hash of the actual message to sign) or any length for EdDSA as prehashing is not required.
           type: string
           example: ababababababababababababababababababbababababababbababababababab
         bip44addressIndex:


### PR DESCRIPTION
Introduce new preHash object in UnsignedMessage schema.
Used for ECDSA RAW signing only.