### PR TITLE
Update api-spec-v2.yaml GET vault/accounts/paged

### DIFF
--- a/api-spec-v2.yaml
+++ b/api-spec-v2.yaml
@@ -369,7 +369,7 @@ paths:
           default:
               $ref: '#/components/responses/Error'
       operationId: getCreateMultipleVaultAccountsJobStatus
-  /vault/accounts/paged:
+  /vault/accounts_paged:
     get:
       summary: Get vault accounts (Paginated)
       description: >-


### PR DESCRIPTION
Updated GET vault/accounts/paged to GET vault/accounts_paged based on end user feedback - this naming path seems to line up with other similar endpoints too (e.g., GET vault/accounts/{vaultAccountId}/{assetId}/addresses_paginated)