### PR TITLE
Corrected sortBy field description + enum values

### DIFF
--- a/api-spec-v2.yaml
+++ b/api-spec-v2.yaml
@@ -11341,10 +11341,17 @@ paths:
         - name: sortBy
           required: false
           in: query
-          description: Sort by field (id, startTime, endTime, status, events, resourceId)
+          description: Sort by field (id, createdAt, updatedAt, status, eventType, resourceId)
           schema:
             default: id
             example: id
+            enum:
+              - id
+              - createdAt
+              - updatedAt
+              - status
+              - eventType
+              - resourceId
             type: string
         - name: pageCursor
           required: false


### PR DESCRIPTION
Per Sharon Weintraub: "The sortBy field should include in the enum the options of (notifications) createdAt, updatedAt it has different meaning than filters of startTime, endTime which are based on notification createdAt timestamp"

Therefore:
- Changed startTime > createdAt
- Changed endTime > updatedAt