### PR TITLE
fix: ExteralWalletAsset and WalletAsset fields

### DIFF
--- a/api-spec-v2.yaml
+++ b/api-spec-v2.yaml
@@ -27302,9 +27302,9 @@ components:
         id:
           type: string
         balance:
-          type: string
+          type: number
         lockedAmount:
-          type: string
+          type: number
         status:
           $ref: '#/components/schemas/ConfigChangeRequestStatus'
         address:
@@ -27678,9 +27678,9 @@ components:
         address:
           type: string
         balance:
-          type: string
+          type: number
         lockedAmount:
-          type: string
+          type: number
         tag:
           type: string
         activationTime:


### PR DESCRIPTION
balance and lockedAmount are returning as numbers. I am not sure if they are float. 

```json
{
  "id": "SOL_TEST",
  "balance": 0,
  "lockedAmount": 0,
  "status": "WAITING_FOR_APPROVAL"
}
```